### PR TITLE
Kotlin syntax highlight

### DIFF
--- a/docusaurus/src/theme/prism-include-languages.js
+++ b/docusaurus/src/theme/prism-include-languages.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import siteConfig from "@generated/docusaurus.config";
+
+const prismIncludeLanguages = (PrismObject) => {
+  if (ExecutionEnvironment.canUseDOM) {
+    const {
+      themeConfig: { prism: { additionalLanguages = [] } = {} },
+    } = siteConfig;
+    window.Prism = PrismObject;
+    additionalLanguages.forEach((lang) => {
+      require(`prismjs/components/prism-${lang}`); // eslint-disable-line
+    });
+    require("prismjs/components/prism-kotlin");
+
+    delete window.Prism;
+  }
+};
+
+export default prismIncludeLanguages;


### PR DESCRIPTION
Enables syntax highlighting for Kotlin. The shorter approach which docusaurus docs recommends did not work for some reason. 