### PR TITLE
[DSA-28/WEF-651]: Fix Head tags urls

### DIFF
--- a/docusaurus/src/theme/Navbar/index.js
+++ b/docusaurus/src/theme/Navbar/index.js
@@ -70,7 +70,7 @@ const SiteNavbar = () => {
       <div className="site-navbar__inner">
         <ul className="site-navbar__breadcrumbs">
           <li>
-            <a href={`${website.root}chat/`}>Chat</a>
+            <a href={`${website.root}/chat/`}>Chat</a>
           </li>
           <li className="separator">»</li>
           <li>

--- a/docusaurus/urls.js
+++ b/docusaurus/urls.js
@@ -6,7 +6,7 @@ module.exports = {
     root: '/chat/docs/sdk/',
   },
   website: {
-    root: `${ROOT}/`,
+    root: `${ROOT}`,
     cms_docs: `${ROOT}/chat/docs/`,
     signup: `${ROOT}/accounts/signup/`,
     // Not needed anymore but will keep it commented in case these values return in another place


### PR DESCRIPTION
Reading the [docusaurus docs](https://docusaurus.io/docs/next/docusaurus.config.js/#url), I found out that the proper way to set the `url` param in config.js should be without the trailing slash.

I removed it form our `URLS` file, and updated the only reference to it I could found. I'm not sure if there are any other internal links that were using it, but after some testing seems everything is fine.

_@tsirlucas let me know if I should change the base branch to `production` if we are not deploying the new docusaurus version_