### PR TITLE
Add product attribute

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -12,7 +12,14 @@ const path = require('path');
 
 const { folderMapping, IGNORED_DIRECTORIES } = require('./constants');
 const URLS = require('./urls');
+const productVariables = require('./src/product-variables');
 const Icons = require('./admonition-icons');
+
+const PRODUCT = process.env.PRODUCT;
+const {
+  productTitle,
+  docusaurus: { title: navbarTitle },
+} = productVariables[PRODUCT];
 
 const CUSTOM_PLUGIN_REGEX = /^docusaurus.*\.plugin.js$/;
 
@@ -184,8 +191,8 @@ module.exports = {
   onBrokenMarkdownLinks: 'warn',
   organizationName: 'GetStream',
   plugins,
-  projectName: 'stream-chat',
-  tagline: 'Stream Chat official component SDKs',
+  projectName: `stream-${PRODUCT}`,
+  tagline: `Stream ${productTitle} official component SDKs`,
   themeConfig: {
     // Docusaurus forces us to pass these values even if they are not internally used.
     // Theyre only used to show/hide the search bar in our case.
@@ -206,10 +213,10 @@ module.exports = {
     navbar: {
       items: navbarItems,
       logo: {
-        alt: 'Chat docs logo',
+        alt: 'Stream docs logo',
         src: 'img/logo.svg',
       },
-      title: 'Chat Messaging',
+      title: navbarTitle,
     },
     metadatas: [{ name: 'twitter:card', content: 'summary_large_image' }],
   },
@@ -226,6 +233,6 @@ module.exports = {
     '@docusaurus/theme-live-codeblock',
     '@docusaurus/theme-search-algolia',
   ],
-  title: 'Stream Chat - Component SDK Docs',
+  title: `Stream ${productTitle} - Component SDK Docs`,
   url: URLS.website.root,
 };

--- a/docusaurus/src/api.js
+++ b/docusaurus/src/api.js
@@ -49,4 +49,4 @@ export const apiDocFeedback = (data) => {
 export const apiGetUser = () => fetchApi('GET', 'api/accounts/user');
 
 export const apiGetPublicUserToken = () =>
-  fetchApi('GET', 'api/core/chat_docs_credentials');
+  fetchApi('GET', 'api/core/chat_docs_credentials'); // activity feeds credentials ???

--- a/docusaurus/src/build-algolia-objects.js
+++ b/docusaurus/src/build-algolia-objects.js
@@ -8,6 +8,17 @@ const {
 } = require('@docusaurus/utils');
 const slugs = require('github-slugger')();
 const { platformMapping, IGNORED_DIRECTORIES } = require('../constants');
+const productVariables = require('./product-variables');
+
+const {
+  algolia: {
+    parentSection: {
+      name: parent_section_name,
+      slug: parent_section_slug,
+      id: parent_section_id,
+    },
+  },
+} = productVariables[process.env.PRODUCT];
 
 const extractSyntaxTree = (path) => {
   // This function takes care of transforming the .md/.mdx file into an
@@ -320,9 +331,6 @@ const extractDocsData = async (docsContent) => {
             .join(' > ');
           const section_slug = sectionsSlug;
           const section_id = sectionsSlug;
-          const parent_section_name = 'Chat API Docs';
-          const parent_section_slug = 'chat_docs';
-          const parent_section_id = 'chat_docs';
           const platform = platformMapping[sdkKey];
           const content_serialized_text = pageData && pageData.text.join('\n');
           const code_sample = pageData && pageData.code.join('\n');

--- a/docusaurus/src/contexts/DocusaurusContext.js
+++ b/docusaurus/src/contexts/DocusaurusContext.js
@@ -11,6 +11,9 @@ import { useLocation } from '@docusaurus/router';
 
 import { folderMapping } from '../../constants';
 import URLS from '../../urls';
+import productVariables from '../product-variables';
+
+const { productTitle } = productVariables[process.env.PRODUCT];
 
 // Dynamically overrides docusaurus context
 // Used to have unique SEO tags for SDK.
@@ -28,7 +31,7 @@ export const DocusaurusContextProvider = ({ children }) => {
 
   const platform = folderMapping[locationPlatform];
   const metaTitle = platform
-    ? `Stream Chat - ${platform} SDK Docs`
+    ? `Stream ${productTitle} - ${platform} SDK Docs`
     : siteConfig.title;
 
   return (

--- a/docusaurus/src/define-env-vars-plugin.js
+++ b/docusaurus/src/define-env-vars-plugin.js
@@ -9,6 +9,7 @@ const OPTIONAL_VARIABLES = [
   'ALGOLIA_API_KEY',
   'WEBSITE_BASE_URL',
   'DEPLOYMENT_ENV',
+  'PRODUCT',
 ];
 
 const filteredVariables = Object.keys(environment).reduce((acc, item) => {
@@ -28,6 +29,7 @@ module.exports = function () {
             ALGOLIA_API_KEY: 'DEFAULT',
             WEBSITE_BASE_URL: 'DEFAULT',
             DEPLOYMENT_ENV: 'staging',
+            PRODUCT: 'chat', // either "chat" or "activity-feeds"
             ...filteredVariables,
           }),
         ],

--- a/docusaurus/src/environment.js
+++ b/docusaurus/src/environment.js
@@ -5,4 +5,5 @@ module.exports = {
   ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID,
   ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,
   WEBSITE_BASE_URL: process.env.WEBSITE_BASE_URL,
+  PRODUCT: process.env.PRODUCT,
 };

--- a/docusaurus/src/product-variables.js
+++ b/docusaurus/src/product-variables.js
@@ -1,0 +1,47 @@
+const GITHUB_ROOT = 'https://github.com/GetStream';
+
+module.exports = {
+  'activity-feeds': {
+    productTitle: 'Activity Feeds',
+    // Algolia stuff
+    algolia: {
+      parentSection: {
+        name: 'Activity Feeds API Docs',
+        slug: 'activity_feeds_docs',
+        id: 'activity_feeds_docs',
+      },
+    },
+    // GitHub stuff
+    github: {
+      android: null,
+      flutter: `${GITHUB_ROOT}/stream-feed-flutter/`,
+      ios: `${GITHUB_ROOT}/swift-activity-feed/`,
+      react: `${GITHUB_ROOT}/react-activity-feed/`,
+      reactnative: `${GITHUB_ROOT}/react-native-activity-feed/`,
+    },
+    // Docusaurus (config) stuff
+    docusaurus: {
+      title: 'Activity Feeds',
+    },
+  },
+  chat: {
+    productTitle: 'Chat',
+    algolia: {
+      parentSection: {
+        name: 'Chat API Docs',
+        slug: 'chat_docs',
+        id: 'chat_docs',
+      },
+    },
+    github: {
+      android: `${GITHUB_ROOT}/stream-chat-android/`,
+      flutter: `${GITHUB_ROOT}/stream-chat-flutter/`,
+      ios: `${GITHUB_ROOT}/stream-chat-swift/`,
+      react: `${GITHUB_ROOT}/stream-chat-react/`,
+      reactnative: `${GITHUB_ROOT}/stream-chat-react-native/`,
+    },
+    docusaurus: {
+      title: 'Chat Messaging',
+    },
+  },
+};

--- a/docusaurus/src/theme/DocSidebar.js
+++ b/docusaurus/src/theme/DocSidebar.js
@@ -5,7 +5,7 @@ import { useBreadcrumbsContext } from '../hooks/useBreadcrumbsContext';
 const WEB_LINKS = [
   ['Contact Support', 'https://getstream.io/contact/support/'],
   ['Maker Account', 'https://getstream.io/maker-account/'],
-  ['Mobile Chat Kit', 'https://getstream.io/chat/ux-kit/'],
+  ['Mobile Chat Kit', 'https://getstream.io/chat/ux-kit/'], // activity feeds ux kit ???
   [
     <>
       © Stream.IO, Inc. <br /> All Rights Reserved.

--- a/docusaurus/src/theme/Layout.js
+++ b/docusaurus/src/theme/Layout.js
@@ -2,21 +2,21 @@ import React, { useEffect, useState } from 'react';
 import OriginalLayout from '@theme-original/Layout';
 import { ToastContainer } from 'react-toastify';
 
+import URLS from '../../urls';
 import { AuthContextProvider } from '../contexts/AuthContext';
 
 const isBrowser = typeof window !== `undefined`;
 const isProd = process.env.DEPLOYMENT_ENV === 'production';
 
 export default function Layout(props) {
-  const isRootPath =
-    isBrowser && window.location.pathname === '/chat/docs/sdk/';
+  const isRootPath = isBrowser && window.location.pathname === URLS.docs.root;
   const [canRender, setCanRender] = useState(!isProd || !isRootPath);
 
   // whick redirect for home page. this should happen here in order to avoid
   // rendering the layout when redirecting.
   useEffect(() => {
     if (isProd && isRootPath) {
-      window.location.replace('https://getstream.io/chat/docs/');
+      window.location.replace(URLS.website.cms_docs);
     } else if (!canRender) {
       setCanRender(true);
     }
@@ -27,9 +27,9 @@ export default function Layout(props) {
   }
 
   return (
-      <AuthContextProvider>
-        <ToastContainer />
-        <OriginalLayout {...props} />
-      </AuthContextProvider>
+    <AuthContextProvider>
+      <ToastContainer />
+      <OriginalLayout {...props} />
+    </AuthContextProvider>
   );
 }

--- a/docusaurus/src/theme/Navbar/index.js
+++ b/docusaurus/src/theme/Navbar/index.js
@@ -8,8 +8,12 @@ import { folderMapping } from '../../../constants';
 import { docs, website } from '../../../urls';
 
 import URLS from '../../../urls';
+import productVariables from '../../product-variables';
 
 import './styles.scss';
+
+const PRODUCT = process.env.PRODUCT;
+const { productTitle } = productVariables[PRODUCT];
 
 export default function Navbar(props) {
   return (
@@ -70,7 +74,7 @@ const SiteNavbar = () => {
       <div className="site-navbar__inner">
         <ul className="site-navbar__breadcrumbs">
           <li>
-            <a href={`${website.root}/chat/`}>Chat</a>
+            <a href={`${website.root}/${PRODUCT}/`}>{productTitle}</a>
           </li>
           <li className="separator">»</li>
           <li>

--- a/docusaurus/src/theme/NavbarItem/index.js
+++ b/docusaurus/src/theme/NavbarItem/index.js
@@ -9,8 +9,6 @@ import URLS from '../../../urls';
 
 import './styles.scss';
 
-const baseUrl = '/chat/docs/sdk';
-
 function GithubReleaseLink({ activeVersion, href }) {
   return (
     activeVersion.name !== 'current' && (
@@ -34,7 +32,9 @@ function CustomNavbarItem(props) {
 
   const selectedSDK = useMemo(() => {
     if (label === 'SDK' && items.length) {
-      return items.find((item) => pathname.includes(`${baseUrl}/${item.id}/`));
+      return items.find((item) =>
+        pathname.includes(`${URLS.docs.root}${item.id}/`)
+      );
     }
   }, [items, label, pathname]);
 
@@ -48,7 +48,7 @@ function CustomNavbarItem(props) {
     type === 'docsVersionDropdown' &&
     pathname
       .replace(' ', '')
-      .search(new RegExp(`${baseUrl}/${docsPluginId}/.*`, 'g')) === -1
+      .search(new RegExp(`${URLS.docs.root}${docsPluginId}/.*`, 'g')) === -1
   ) {
     return null;
   }
@@ -94,7 +94,7 @@ const PlatformNavbarItem = ({ items, ...props }) => {
 const PlatformLabel = ({ id, label }) => (
   <span className="navbar__link__sdk">
     <img
-      src={`${baseUrl}/icon/${id}.svg`}
+      src={`${URLS.docs.root}icon/${id}.svg`}
       alt={`${label} logo`}
       className="navbar__link__sdk__icon"
     />

--- a/docusaurus/src/theme/SearchBar/DocSearchModal.js
+++ b/docusaurus/src/theme/SearchBar/DocSearchModal.js
@@ -19,6 +19,13 @@ import {
   CMS_INDEX,
 } from '../../../constants';
 import environment from '../../environment';
+import productVariables from '../../product-variables';
+
+const {
+  algolia: {
+    parentSection: { slug: parentSectionSlug },
+  },
+} = productVariables[process.env.PRODUCT];
 
 const algoliaClient = algoliasearch(
   environment.ALGOLIA_APP_ID,
@@ -121,7 +128,7 @@ export function DocSearchModal({
                 type: 'default',
                 query,
                 params: {
-                  filters: `parent_section_slug:chat_docs AND platform:${platformMapping[locationPlatform]} AND version:${activeVersion.name}`,
+                  filters: `parent_section_slug:${parentSectionSlug} AND platform:${platformMapping[locationPlatform]} AND version:${activeVersion.name}`,
                 },
               },
               {
@@ -129,7 +136,7 @@ export function DocSearchModal({
                 type: 'default',
                 query,
                 params: {
-                  filters: `parent_section_slug:chat_docs AND platforms:${platformMapping[locationPlatform]}`,
+                  filters: `parent_section_slug:${parentSectionSlug} AND platforms:${platformMapping[locationPlatform]}`,
                 },
               },
             ])

--- a/docusaurus/src/theme/SearchBar/getItemUrl.js
+++ b/docusaurus/src/theme/SearchBar/getItemUrl.js
@@ -1,6 +1,6 @@
 import url from 'url';
 
-import { website } from '../../../urls';
+import { website, docs } from '../../../urls';
 import { CMS_INDEX } from '../../../constants';
 
 export const getItemUrl = ({ item, platform, cmsPlatform, locationQuery }) => {
@@ -12,8 +12,8 @@ export const getItemUrl = ({ item, platform, cmsPlatform, locationQuery }) => {
     })}${!!headerId ? `#${headerId}` : ''}`;
   }
 
-  return `/chat/docs/sdk${url.format({
-    pathname: item.slug === '' ? `/${platform}/` : `/${platform}/${item.slug}/`,
+  return `${docs.root}${url.format({
+    pathname: item.slug === '' ? `${platform}/` : `${platform}/${item.slug}/`,
     query: locationQuery,
   })}${!!headerId ? `#${headerId}` : ''}`;
 };

--- a/docusaurus/urls.js
+++ b/docusaurus/urls.js
@@ -1,13 +1,18 @@
 const ROOT = 'https://getstream.io';
 const GITHUB_ROOT = 'https://github.com/GetStream';
 
+const productVariables = require('./src/product-variables');
+
+const PRODUCT = process.env.PRODUCT;
+const { github } = productVariables[PRODUCT];
+
 module.exports = {
   docs: {
-    root: '/chat/docs/sdk/',
+    root: `/${PRODUCT}/docs/sdk/`,
   },
   website: {
     root: `${ROOT}`,
-    cms_docs: `${ROOT}/chat/docs/`,
+    cms_docs: `${ROOT}/${PRODUCT}/docs/`,
     signup: `${ROOT}/accounts/signup/`,
     // Not needed anymore but will keep it commented in case these values return in another place
     // main: [
@@ -113,11 +118,5 @@ module.exports = {
     ],
   },
   github_root: GITHUB_ROOT,
-  github: {
-    android: `${GITHUB_ROOT}/stream-chat-android/`,
-    flutter: `${GITHUB_ROOT}/stream-chat-flutter/`,
-    ios: `${GITHUB_ROOT}/stream-chat-swift/`,
-    react: `${GITHUB_ROOT}/stream-chat-react/`,
-    reactnative: `${GITHUB_ROOT}/stream-chat-react-native/`,
-  },
+  github,
 };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "stream-chat-docusaurus-cli",
+  "name": "stream-docusaurus-cli",
   "version": "1.0.0",
   "description": "Stream Chat Docusaurus CLI",
   "main": "index.js",
   "bin": {
-    "stream-chat-docusaurus": "./init.sh"
+    "stream-docusaurus": "./init.sh"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -18,5 +18,9 @@
   "bugs": {
     "url": "https://github.com/GetStream/stream-chat-docusaurus-cli/issues"
   },
-  "homepage": "https://github.com/GetStream/stream-chat-docusaurus-cli#readme"
+  "homepage": "https://github.com/GetStream/stream-chat-docusaurus-cli#readme",
+  "prettier": {
+    "useTabs": false,
+    "singleQuote": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "stream-docusaurus-cli",
+  "name": "stream-chat-docusaurus-cli",
   "version": "1.0.0",
   "description": "Stream Chat Docusaurus CLI",
   "main": "index.js",
   "bin": {
-    "stream-docusaurus": "./init.sh"
+    "stream-chat-docusaurus": "./init.sh"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Added support for environment variable `PRODUCT` (`chat` or `activity-feeds`) which is used to determine whether to generate links (and other things) for one product or the other. Variables are mapped accordingly in `product-variables.js`. I also suggest renaming the package to `stream-docusaurus` since it now supports Activity Feeds too.