### PR TITLE
Explicitly exit with with a non-zero exit code on Algolia error

### DIFF
--- a/docusaurus/replace-algolia-objects.js
+++ b/docusaurus/replace-algolia-objects.js
@@ -19,4 +19,7 @@ index
   .then(({ objectIDs }) => {
     console.log(`Updated ${DOCUSAURUS_INDEX} Algolia index for: `, objectIDs);
   })
-  .catch((e) => console.log('ERROR: ', e));
+  .catch((error) => {
+    console.error(`Error while replacing object with Algolia: ${ error }`);
+    process.exit(1);
+  });


### PR DESCRIPTION
Apparently, algolia has thrown an arror saying `Invalid Application-ID or API key`, but since we catch the error and just log it the workflow doesn't fail and the error slips past us silently.

This should force it to stop the workflow on any error from Algolia.