### PR TITLE
fix: react native video link

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,7 @@ const TUTORIALS = [
   },
   {
     sdk: 'React Native',
-    link: 'react-native/basics/tutorial',
+    link: 'reactnative/basics/tutorial',
     description:
       'Build an video calling mobile app that works on both iOS and Android.',
   },


### PR DESCRIPTION
`reactnative` should be used instead of `react-native`

to be compliant with https://github.com/GetStream/stream-chat-docusaurus-cli/blob/3ed7c94b10a8a12b2bd45e0f89b41eb6bf867e27/constants.js#L6