### PR TITLE
fix: lock react version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 /.log/
 .docusaurus
 *_version*
+.idea/

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -272,6 +272,20 @@ plugins.push(
   path.resolve(__dirname, 'src/build-algolia-objects')
 );
 
+plugins.push(() => ({
+  // lock the React version to that used by docusaurus
+  name: 'resolve-react',
+  configureWebpack() {
+    return {
+      resolve: {
+        alias: {
+          react: path.resolve('./node_modules/react'),
+        },
+      },
+    };
+  },
+}),);
+
 module.exports = {
   baseUrl: URLS.docs.root,
   trailingSlash: true,


### PR DESCRIPTION
## Goal

Prevent the possibility that React version local to the SDK repo would be used to build the docs instead of the one used by stream-chat-docusaurus-cli.

Importing two different versions of React leads to crash of the docs site resp. failure to generate the docs statically.

![image](https://user-images.githubusercontent.com/32706194/232618529-15e39bec-16b7-4c19-b6df-bd1159fbeb1f.png)

**Note**

This fix was smoked tested (run the docs site locally) with:

- stream-(chat|video)-react
- stream-(chat|video)-react-native
- stream-(chat|video)-angular
- stream-(chat|video)-flutter
- stream-(chat|video)-swift
- stream-(chat|video)-android
