### PR TITLE
feat: diff highlight for codeblocks

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -162,6 +162,38 @@ html[data-theme="dark"] {
   padding: 0 var(--ifm-pre-padding);
 }
 
+.docusaurus-highlight-removed-code-lines {
+  background-color: #453a45;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}
+
+.docusaurus-highlight-removed-code-lines::before {
+  content: "−";
+  color: #fff;
+  display: inline-block;
+  width: 1em;
+  // margin-right: 0.5em;
+  text-align: right;
+}
+
+.docusaurus-highlight-added-code-lines {
+  background-color: #354947;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}
+
+.docusaurus-highlight-added-code-lines::before {
+  content: "+";
+  color: #fff;
+  display: inline-block;
+  width: 1em;
+  // margin-right: 0.5em;
+  text-align: right;
+}
+
 // Overrides default from infima once we need this spacing otherwise feedback form button
 // gets too close to the markdown section
 // !important needed because new docusaurus version sets it to 0 with a !important flag

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -20,13 +20,13 @@ const prismIncludeLanguages = PrismObject => {
     })
     magicComments.push({
       className: "docusaurus-highlight-removed-code-lines",
-      line: "Next line is removed",
-      block: { start: "Removed lines start", end: "Removed lines end" },
+      line: "removed-line",
+      block: { start: "removed-block-start", end: "removed-block-end" },
     })
     magicComments.push({
       className: "docusaurus-highlight-added-code-lines",
-      line: "Next line is added",
-      block: { start: "Added lines start", end: "Added lines end" },
+      line: "added-line",
+      block: { start: "added-block-start", end: "added-block-end" },
     })
 
     require("prismjs/components/prism-kotlin")

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -10,12 +10,25 @@ import siteConfig from "@generated/docusaurus.config"
 const prismIncludeLanguages = PrismObject => {
   if (ExecutionEnvironment.canUseDOM) {
     const {
-      themeConfig: { prism: { additionalLanguages = [] } = {} },
+      themeConfig: {
+        prism: { additionalLanguages = [], magicComments = [] } = {},
+      },
     } = siteConfig
     window.Prism = PrismObject
     additionalLanguages.forEach(lang => {
       require(`prismjs/components/prism-${lang}`) // eslint-disable-line
     })
+    magicComments.push({
+      className: "docusaurus-highlight-removed-code-lines",
+      line: "Next line is removed",
+      block: { start: "Removed lines start", end: "Removed lines end" },
+    })
+    magicComments.push({
+      className: "docusaurus-highlight-added-code-lines",
+      line: "Next line is added",
+      block: { start: "Added lines start", end: "Added lines end" },
+    })
+
     require("prismjs/components/prism-kotlin")
     require("prismjs/components/prism-swift")
     require("prismjs/components/prism-java")


### PR DESCRIPTION
Ability to show diff highlight for codeblocks:

```
  ```tsx
  export const MyComponent = () => {
    useEffect(() => {
      // removed-block-start
      console.log('Old log statement 1');
      console.log('Old log statement 2');
      console.log('Old log statement 3');
      // removed-block-end
      // added-block-start
      console.log('New log statement 1');
      console.log('New log statement 2');
      // added-block-end
    }, []);
    })
    // removed-line
    return <div>MyComponent</div>;
    // added-line
    return <p>MyComponent</p>;
  };
  ```


<img width="838" alt="Screenshot 2023-08-29 at 01 14 16" src="https://github.com/GetStream/stream-chat-docusaurus-cli/assets/11586388/afe78a52-377f-4d5f-91d3-7987839e6cb5">
