### PR TITLE
fix: add missing run keyword

### DIFF
--- a/bin.sh
+++ b/bin.sh
@@ -64,7 +64,7 @@ main() {
       echo "Missing NEW_VERSION or SDK_NAME. Skipping versioning.."
     else
       cd $PACKAGE_DIR
-      npm docusaurus docs:version:"$SDK_NAME" "$NEW_VERSION";
+      npm run docusaurus docs:version:"$SDK_NAME" "$NEW_VERSION";
 
       if [ ! -d "$CURRENT_WORKING_PATH/docusaurus/${SDK_NAME}_versioned_docs" ]; then
         cp -r "$SDK_NAME"* "$CURRENT_WORKING_PATH"/docusaurus


### PR DESCRIPTION
When trying to create a new version through the `--new-version` flag the `npm` script would be called without the `run` keyword immediately failing and erroring out:

![Screenshot 2024-02-19 at 9 55 52 PM](https://github.com/GetStream/stream-chat-docusaurus-cli/assets/43254280/3a3d09d0-e059-4e4c-bdb3-d052b4e94fcf)
