### PR TITLE
fix: folder mapping for react native sdk

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -3,7 +3,7 @@ const folderMapping = {
   flutter: "Flutter",
   ios: "iOS",
   react: "React",
-  reactnative: "React Native",
+  reactnative: "React-Native",
   angular: "Angular",
   api: "API",
   javascript: "JavaScript",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,7 +12,7 @@ import { folderMapping } from "../../constants"
 import styles from "./styles.module.css"
 
 const Feature = ({ title }) => {
-  const platform = `${title.toLowerCase().replace(" ", "")}`
+  const platform = `${title.toLowerCase().replace("-", "")}`
   return (
     <div className={clsx("col col--2", styles.feature)}>
       <div className={styles.buttons}>


### PR DESCRIPTION
When trying to create sidebars.json for react native SDK the order and the titles were messed up because of the wrong folder mapping that was done before.

Before: `sidebars-React Native`
Now: `sidebars-react-native`

This PR tends to fix this issue.