### PR TITLE
fix: apply font styling to direct child only

### DIFF
--- a/src/css/components/menu.scss
+++ b/src/css/components/menu.scss
@@ -180,7 +180,7 @@ html[data-theme="dark"] {
     }
 
     .theme-doc-sidebar-item-category-level-1 {
-      .menu__list-item-collapsible {
+      & > .menu__list-item-collapsible {
         font-size: 0.6875rem;
         font-weight: 700;
         letter-spacing: 0.0825rem;


### PR DESCRIPTION
Fixes a styling issue where first collapsible element (second level) gets the same styling as the first level collapsible element resulting in broken-looking UI.

Before:
![Screenshot 2024-02-21 at 4 39 08 PM](https://github.com/GetStream/stream-chat-docusaurus-cli/assets/43254280/4441fbe4-983f-4e57-a7b5-f40f05844c95)

After:
![Screenshot 2024-02-21 at 4 38 47 PM](https://github.com/GetStream/stream-chat-docusaurus-cli/assets/43254280/8dc9ca76-1a8e-4711-bf61-a9759a7a6759)
