### PR TITLE
feat: support image series

### DIFF
--- a/src/css/components/markdown.scss
+++ b/src/css/components/markdown.scss
@@ -10,8 +10,18 @@
       background-color: #edeeeb;
 
       @media (min-width: 997px) {
-        padding: 2.25rem;
-        border-radius: 1rem;
+        padding: 2.25rem 2.25rem 0;
+
+        &:first-child {
+          border-top-left-radius: 1rem;
+          border-top-right-radius: 1rem;
+        }
+
+        &:last-child {
+          padding-bottom: 2.25rem;
+          border-bottom-left-radius: 1rem;
+          border-bottom-right-radius: 1rem;
+        }
       }
     }
 


### PR DESCRIPTION
Add support for a series of images going one after another.

Before - weird adjacent border radii, too much spacing between images:

<img width="1493" alt="Screenshot 2024-03-27 at 17 56 07" src="https://github.com/GetStream/stream-chat-docusaurus-cli/assets/975978/5ef43f11-82d3-402b-9b7d-6684d69daffe">

After:

<img width="1493" alt="Screenshot 2024-03-27 at 17 55 42" src="https://github.com/GetStream/stream-chat-docusaurus-cli/assets/975978/beabe850-067f-41f6-b3b5-6cffad0d4f28">